### PR TITLE
Fix double volume icon

### DIFF
--- a/.config/polybar/modules/system.ini
+++ b/.config/polybar/modules/system.ini
@@ -13,7 +13,7 @@ label-volume-prefix-underline = ${colors.purple-1}
 label-volume-prefix-background = ${colors.bg-1}
 label-volume-prefix-foreground = ${colors.purple-1}
 
-format-muted = <label-muted><ramp-volume>
+format-muted = <label-muted>
 label-muted = "ﱝ "
 label-muted-underline = ${colors.red-2}
 label-muted-background = ${colors.bg-1}


### PR DESCRIPTION
I really loved your polybar customization and wanted to fix a slight bug that shows double volume icon when muted
![image](https://user-images.githubusercontent.com/65122296/231874206-c986cf00-5208-434c-8aa9-93495bf15593.png)
after:
![image](https://user-images.githubusercontent.com/65122296/231874298-e53d2223-fdbf-4ed6-8267-8e5c479821e9.png)
